### PR TITLE
truncate floating point when cropping profile image

### DIFF
--- a/routes/@[username]/settings/index.tsx
+++ b/routes/@[username]/settings/index.tsx
@@ -135,8 +135,8 @@ export const handler = define.handlers({
       }
       if (width !== height) { // crop to square
         const size = Math.min(width, height);
-        const left = (width - size) / 2;
-        const top = (height - size) / 2;
+        const left = ((width - size) / 2) | 0;
+        const top = ((height - size) / 2) | 0;
         image = image.extract({ left, top, width: size, height: size });
         width = height = size;
       }


### PR DESCRIPTION

프로필 이미지를 바꾸기 위해 이미지를 교체하고 저장을 눌렀더니 500이 발생합니다.

전달받은 에러:

```
Error: Expected integer for top but received 259.5 of type number
    at Object.invalidParameterError (file:///app/node_modules/.deno/sharp@0.33.5/node_modules/sharp/lib/is.js:135:10)
    at Sharp.<anonymous> (file:///app/node_modules/.deno/sharp@0.33.5/node_modules/sharp/lib/resize.js:483:16)
    at Array.forEach (<anonymous>)
    at Sharp.extract (file:///app/node_modules/.deno/sharp@0.33.5/node_modules/sharp/lib/resize.js:478:38)
    at POST (file:///app/routes/@[username]/settings/index.tsx:140:23)
    at async https://jsr.io/@fresh/core/2.0.0-alpha.29/src/plugins/fs_routes/render_middleware.ts:40:23
    at async https://jsr.io/@fresh/core/2.0.0-alpha.29/src/plugins/fs_routes/render_middleware.ts:36:19
    at async FreshReqContext.fn (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/mod.ts:99:18)
    at async FreshReqContext.fn (https://jsr.io/@fresh/core/2.0.0-alpha.29/src/middlewares/mod.ts:99:18)
    at async file:///app/routes/_middleware.ts:57:14
```

다른 곳에도 이런 코드가 있을 가능성이 있고, 테스트 코드도 작성하진 않았지만 일단 기여를 해봅니다.



unexpected space
