### PR TITLE
Fix the "quote" SVG icon

### DIFF
--- a/islands/PostControls.tsx
+++ b/islands/PostControls.tsx
@@ -213,7 +213,7 @@ export function PostControls(props: PostControlsProps) {
               stroke="currentColor"
             >
               <path d="M4 9v-1a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1h4a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2v2l-2-2h-6a2 2 0 0 1-2-2v-2a2 2 0 0 1 2-2h4m0 6v1a2 2 0 0 1-2 2h-8a2 2 0 0 1-2-2v-4m-2 2l2-2l2 2" />
-              <path stroke-linecap="round" d="M14 12v.01m2 0v-.01m2 0v.01" />
+              <path stroke-linecap="round" d="M13 12v.01m3 0v-.01m3 0v.01" />
             </svg>
           )}
       </div>


### PR DESCRIPTION
Oops I'm really sorry for the trouble. Realized a mistake a bit too late. The "quote" SVG icon I suggested will not look nice on the displays with the standard 96 DPI.

AS-IS, 240px:

![AS-IS 240px](https://github.com/user-attachments/assets/020bd56a-70d9-43d3-b35b-57c81d0a49a5)

AS-IS, 24px (with 10x zoom):

![AS-IS 24px](https://github.com/user-attachments/assets/87896ad8-efec-4353-99d0-d612de49e8b8)

TO-BE, 240px:

![TO-BE 240px](https://github.com/user-attachments/assets/9e2dacfd-7d6b-462e-b54a-385907367133)

TO-BE, 24px (with 10x zoom):

![TO-BE 24px](https://github.com/user-attachments/assets/3dd0441f-11f7-49cb-b376-2c19b5e0b16f)

The difference is the spacing between the dots that make up the ellipsis inside the callout (the speech bubble). I think the new version will deliver the meaning more legibly even on the devices that are not HiDPI.

I fear that the previous one may get mistaken for a completely different meaning (e.g. a hard disk drive?).

What do you think?